### PR TITLE
feat: add language-filter option (#20)

### DIFF
--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -63,9 +63,11 @@ local configurations = function(opts)
   opts = opts or {}
 
   local results = {}
-  for _, lang in pairs(dap.configurations) do
-    for _, config in ipairs(lang) do
-      table.insert(results, config)
+  for lang, configs in pairs(dap.configurations) do
+    if opts.language_filter == nil or opts.language_filter(lang) then
+      for _, config in ipairs(configs) do
+        table.insert(results, config)
+      end
     end
   end
 


### PR DESCRIPTION
**Why** is the change needed?

I define similar configuration for a bunch of similar filetypes. This leads to duplicates in the configuration list.

**How** is the need addressed?

Support a language_filter option that can be used as follows:

```lua
  require("telescope").extensions.dap.configurations {
    language_filter = function(lang)
      return lang == vim.bo.filetype
    end,
  }
```

Side-effects of the changes:

- Change variable naming to be consistent with the usage.